### PR TITLE
Allow console access of bot.py

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -27,7 +27,7 @@ else:
     with open(f"{os.path.realpath(os.path.dirname(__file__))}/config.json") as file:
         config = json.load(file)
 
-"""	
+"""
 Setup bot intents (events restrictions)
 For more information about intents, please go to the following websites:
 https://discordpy.readthedocs.io/en/latest/intents.html
@@ -302,4 +302,6 @@ async def load_cogs() -> None:
 
 asyncio.run(init_db())
 asyncio.run(load_cogs())
-bot.run(config["token"])
+
+if __name__ == "__main__":
+    bot.run(config["token"])


### PR DESCRIPTION
Use the `if name == "main"` pattern in bot.py, the main entry point.

Now we have can have a console in the bot environment:

```
$ python
Python 3.10
Type "help", "copyright", "credits" or "license" for more information.
>>> import bot
2023-03-31 18:20:45 INFO     discord_bot Loaded extension 'template'
2023-03-31 18:20:45 INFO     discord_bot Loaded extension 'fun'
2023-03-31 18:20:45 INFO     discord_bot Loaded extension 'owner'
2023-03-31 18:20:45 INFO     discord_bot Loaded extension 'general'
>>> bot
<module 'bot' from '/home/jack/code/challenge-bot/bot.py'>
>>> bot.bot
<discord.ext.commands.bot.Bot object at 0x7faf43408c40>
>>>
>>> import asyncio
>>> import helpers.db_manager as db_manager
>>> asyncio.run(db_manager.get_activities_for_user(42))
[('42', 'walk', '1680304538'), ('42', 'run', '1680304553'), ('42', 'yoga', '1680304555')]
```